### PR TITLE
友人にアプリを教える機能を削除

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,7 +79,6 @@ dependencies {
     // google-services.jsonがソースコード公開のためにモックになっているため。
     releaseImplementation 'com.google.firebase:firebase-core:17.2.1'
     releaseImplementation 'com.google.firebase:firebase-messaging:20.1.0'
-    releaseImplementation 'com.google.firebase:firebase-invites:17.0.0'
 
     // Preference
     implementation 'androidx.preference:preference:1.1.0'

--- a/app/src/main/java/jp/bellware/echo/view/setting/SettingFragment.kt
+++ b/app/src/main/java/jp/bellware/echo/view/setting/SettingFragment.kt
@@ -16,14 +16,6 @@ class SettingFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.setting)
         run {
-            //紹介
-            val pref = findPreference<Preference>(PREF_INVITE)
-            pref?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
-                callInviteActivity()
-                true
-            }
-        }
-        run {
             //商品情報
             val pref = findPreference<Preference>(PREF_ABOUT)
             pref?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
@@ -51,14 +43,6 @@ class SettingFragment : PreferenceFragmentCompat() {
 
     }
 
-    private fun callInviteActivity() {
-        //ソースコード公開用に招待は無効
-        //        Intent intent = new AppInviteInvitation.IntentBuilder(getString(R.string.pref_invite))
-        //                .setDeepLink(Uri.parse("https://cp999.app.goo.gl/cffF"))
-        //                .build();
-        //        startActivityForResult(intent,1);
-    }
-
     private fun callAboutActivity() {
         val intent = Intent(activity, AboutActivity::class.java)
         startActivity(intent)
@@ -79,8 +63,6 @@ class SettingFragment : PreferenceFragmentCompat() {
     companion object {
 
         private const val PREF_ABOUT = "about"
-
-        private const val PREF_INVITE = "invite"
 
         private const val PREF_OSS = "oss"
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -21,7 +21,6 @@
     <string name="error">エラー</string>
     <string name="ok">OK</string>
     <string name="error_google_auth">Googleアカウント認証が</string>
-    <string name="pref_invite">友人にアプリを紹介する</string>
     <string name="message_permission">このアプリはマイクの権限が必要です。</string>
     <string name="title_permission">情報</string>
     <string name="cancel">キャンセル</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,6 @@
     <!-- 設定画面 -->
     <string name="title_setting">Settings</string>
     <string name="pref_sound">Sound effect</string>
-    <string name="pref_invite">Tell this app</string>
     <string name="pref_information">Information</string>
     <string name="pref_oss">Open source license</string>
     <string name="version" translatable="false">Version</string>

--- a/app/src/main/res/xml/setting.xml
+++ b/app/src/main/res/xml/setting.xml
@@ -5,9 +5,6 @@
         android:key="soundEffect"
         android:title="@string/pref_sound" />
     <Preference
-        android:key="invite"
-        android:title="@string/pref_invite" />
-    <Preference
         android:key="about"
         android:title="@string/pref_information" />
     <Preference


### PR DESCRIPTION
Firebase Invitesは非推奨になったため。