### PR TITLE
Firebase Messagingの動作を確認する。

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,9 +78,10 @@ dependencies {
     // Firebase
     // Debugビルドでは実行できないためReleaseビルドでしか使わない。
     // google-services.jsonがソースコード公開のためにモックになっているため。
-    releaseImplementation 'com.google.firebase:firebase-core:17.2.1'
+    releaseImplementation 'com.google.firebase:firebase-core:17.2.2'
     releaseImplementation 'com.google.firebase:firebase-messaging:20.1.0'
     releaseImplementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'
+    releaseImplementation 'com.google.firebase:firebase-messaging:20.1.0'
 
     // Preference
     implementation 'androidx.preference:preference:1.1.0'

--- a/app/src/debug/java/jp/bellware/echo/util/MyFirebaseMessagingService.kt
+++ b/app/src/debug/java/jp/bellware/echo/util/MyFirebaseMessagingService.kt
@@ -1,0 +1,15 @@
+package jp.bellware.echo.util
+
+import android.app.IntentService
+import android.content.Intent
+
+/**
+ * ダミー実装。
+ */
+class MyFirebaseMessagingService : IntentService("MyFirebaseMessagingService") {
+    override fun onHandleIntent(intent: Intent?) {
+
+    }
+
+
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,8 +10,8 @@
         android:name=".di.QuickEchoApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
-        android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
         android:theme="@style/AppTheme">
 
         <activity
@@ -58,6 +58,15 @@
         <activity
             android:name=".view.setting.AboutActivity"
             android:label="@string/pref_information" />
+
+        <!-- Firebase Messaging Service -->
+        <service
+            android:name=".util.MyFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/app/src/release/java/jp/bellware/echo/util/MyFirebaseMessagingService.kt
+++ b/app/src/release/java/jp/bellware/echo/util/MyFirebaseMessagingService.kt
@@ -1,16 +1,15 @@
 package jp.bellware.echo.util
 
-import android.util.Log
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 
 class MyFirebaseMessagingService : FirebaseMessagingService() {
 
     override fun onNewToken(token: String) {
-        Log.d("Takada", "onNewToken $token")
+        BWU.log("onNewToken $token")
     }
 
     override fun onMessageReceived(message: RemoteMessage) {
-        Log.d("Takada", "onMessageReceived %s".format(message.data))
+        BWU.log("onMessageReceived %s".format(message.data))
     }
 }

--- a/app/src/release/java/jp/bellware/echo/util/MyFirebaseMessagingService.kt
+++ b/app/src/release/java/jp/bellware/echo/util/MyFirebaseMessagingService.kt
@@ -1,0 +1,16 @@
+package jp.bellware.echo.util
+
+import android.util.Log
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+
+class MyFirebaseMessagingService : FirebaseMessagingService() {
+
+    override fun onNewToken(token: String) {
+        Log.d("Takada", "onNewToken $token")
+    }
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        Log.d("Takada", "onMessageReceived %s".format(message.data))
+    }
+}


### PR DESCRIPTION
Firebase Admin SDK for Javaからトークンを持ってメッセージを送る。[送信側](https://github.com/tfandkusu/TryFirebaseAdminSDK/blob/master/src/main/kotlin/com/tfandkusu/tfas/SendFirebaseMessaging.kt)

AWS SNSを使ってメッセージを送る。
[参考文献](https://aws.amazon.com/jp/premiumsupport/knowledge-center/create-android-push-messaging-sns/)