### PR TITLE
警告表示が1回しか表示出来ない問題を修正

### DIFF
--- a/main/src/main/java/jp/bellware/echo/view/main/MainFragment.kt
+++ b/main/src/main/java/jp/bellware/echo/view/main/MainFragment.kt
@@ -296,6 +296,7 @@ class MainFragment : Fragment() {
      */
     private fun showWarning(resId: Int) {
         warning_card.visibility = View.VISIBLE
+        warning_card.alpha = 1f
         warning_text.setText(resId)
         val animator = ObjectAnimator.ofFloat(warning_card, View.ALPHA, 1f, 0f)
         animator.startDelay = 3000


### PR DESCRIPTION
# 再現方法

1. 録音ボタンを押す
2. 何も録音せずに再生ボタンを押す
3. `なにも録音されていません。` 表示が出る
4. 録音ボタンを押す
5. 何も録音せずに再生ボタンを押す
6. `なにも録音されていません。` 表示が出ない。表示が出ることが期待する動作。

# 原因

アルファチャンネルを1に戻していなかった。