### PR TITLE
minSdkVersionを24にする。

### DIFF
--- a/gradle/common.gradle
+++ b/gradle/common.gradle
@@ -5,7 +5,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 24
         targetSdkVersion 29
         versionCode major * 10000 + minor * 100 + patch
         versionName "${major}.${minor}.${patch}"


### PR DESCRIPTION
# 理由

APIレベル23以下ではAACファイルのデコードのための[MediaExtractor#selectTrack](https://developer.android.com/reference/android/media/MediaExtractor#selectTrack(int))で強制終了するため。
音声不可逆圧縮技術の深掘りよりも、ポートフォリオアプリとしての機能の充実を優先したい。
